### PR TITLE
Fix reconnection after oracledb DCD

### DIFF
--- a/src/nodejs/oracledb.ts
+++ b/src/nodejs/oracledb.ts
@@ -223,7 +223,7 @@ module.exports = function (RED) {
               requestingNode.error("Oracle query error: " + err.message);
               var errorCode = err.message.slice(0, 9);
               node.status.emit("error", err);
-              if (errorCode === "ORA-03113" || errorCode === "ORA-03114") {
+              if (errorCode === "DPI-1010:" || errorCode === "DPI-1080:" ||errorCode === "ORA-03113" || errorCode === "ORA-03114") {
                 // start reconnection process
                 node.connection = null;
                 if (node.reconnect) {


### PR DESCRIPTION
Reconnection logic: Support the Node oracledb v5.2.0+ improved dead connection detection.
See https://github.com/oracle/node-oracledb/blob/main/CHANGELOG.md#node-oracledb-v520-7-jun-2021
Solves issue #9 (plus potentially #6 and #7 as well, since DPI-1010 leads to DPI-1080 and eventually NJS-003).