### PR TITLE
Trigger the catch node on error

### DIFF
--- a/lib/oracledb.js
+++ b/lib/oracledb.js
@@ -212,7 +212,7 @@ module.exports = function (RED) {
                 node.connection.execute(query, values, options, function (err, result) {
                     if (err) {
                         var errorCode = err.message.slice(0, 9);
-                        requestingNode.error("Oracle query error: " + err.message + ", errorCode:" + errorCode);
+                        requestingNode.error("Oracle query error: " + err.message + ", errorCode:" + errorCode, msg);
                         node.status.emit("error", err);
 
                         requestingNode.log("Checking errors for retry");


### PR DESCRIPTION
### Issue Description

In the `node-red-contrib-oracledb-mod` module, when attempting to simulate an exceptional case (e.g. inserting a duplicate primary key), the Oracle database exception is correctly logged in the console. However, the exception is not thrown: I tried using the 'catch' node to handle exceptions thrown by the `oracledb` node, but the 'catch' node is never activated, resulting in the flow hanging indefinitely.

### Solution

I noticed that in cases of exceptions, the `oracledb` module fails to trigger the 'catch' node correctly, causing the exception to go uncaught. After investigating the source code, I made the following changes to address this issue:

```
requestingNode.error("Oracle query error: " + err.message + ", errorCode:" + errorCode, msg);
```

This issue is similar to #5 .

I have tested this fix in my local environment, and it successfully triggers the 'catch' node to handle exceptional scenarios, allowing the flow to continue running without hanging.

### Testing Environment

- Node-Red Version: 1.3.5
- node-red-contrib-oracledb-mod Version: 0.6.3 

### Commit Details

I have made the necessary changes and tested them in my local environment. I am confident that this solution addresses the issue of exceptions not being properly caught. If you have any suggestions or feedback, please feel free to let me know. Thank you for your time and review!