### PR TITLE
Ensure port validation returns boolean

### DIFF
--- a/src/html/oracle-server.ts
+++ b/src/html/oracle-server.ts
@@ -13,7 +13,7 @@ RED.nodes.registerType("oracle-server", {
         instantclientpath: { value: "" },
         host: { value: "localhost", required: false },
         port: { value: 1521, required: false, validate: function(v) {
-            return v == null || v.match(/^(\s*|\d+|null)$/);
+            return v == null || !!v.match(/^(\s*|\d+|null)$/);
         }},
         reconnect: {value: true},
         reconnecttimeout: { value: 5000, validate: RED.validators.number() },


### PR DESCRIPTION
The port validation on `oracle-server` wasn't returning a boolean - it was relying on the truthiness of what `String.match()` returns. Since Node-RED 3.1, if a validator returns an array, that is interpreted as a validation error (with the array containing reason messages). This means the config node is failing validation and it gets flagged as an error in the editor.

This PR ensures the validation returns a boolean.